### PR TITLE
OPTION to disable auto reset from PIR

### DIFF
--- a/MySensors.coffee
+++ b/MySensors.coffee
@@ -302,8 +302,7 @@ module.exports = (env) ->
 
       @board.on('rfValue', (result) =>
         if result.sender is @config.nodeid and result.type is V_TRIPPED and result.sensor is @config.sensorid
-          if @config.logLevel is "info"
-            env.logger.info "<- MySensorPIR ", result
+          env.logger.info "<- MySensorPIR ", result
           if result.value is ZERO_VALUE
             @_setPresence(no)
           else

--- a/MySensors.coffee
+++ b/MySensors.coffee
@@ -302,16 +302,16 @@ module.exports = (env) ->
 
       @board.on('rfValue', (result) =>
         if result.sender is @config.nodeid and result.type is V_TRIPPED and result.sensor is @config.sensorid
-          env.logger.debug "<- MySensorPIR ", result
+          if @config.logLevel is "info"
+            env.logger.info "<- MySensorPIR ", result
           if result.value is ZERO_VALUE
             @_setPresence(no)
           else
             @_setPresence(yes)
-          clearTimeout(@_resetPresenceTimeout)
          if @config.autoReset is true
-              clearTimeout(@_resetContactTimeout)
-              @_resetContactTimeout = setTimeout(( =>
-                @_setContact(!hasContact)
+              clearTimeout(@_resetPresenceTimeout)
+              @_resetPresenceTimeout = setTimeout(( =>
+                @_setPresence(no)
               ), @config.resetTime)
       )
       super()

--- a/MySensors.coffee
+++ b/MySensors.coffee
@@ -302,11 +302,17 @@ module.exports = (env) ->
 
       @board.on('rfValue', (result) =>
         if result.sender is @config.nodeid and result.type is V_TRIPPED and result.sensor is @config.sensorid
-          env.logger.info "<- MySensorPIR ", result
-          unless result.value is ZERO_VALUE
+          env.logger.debug "<- MySensorPIR ", result
+          if result.value is ZERO_VALUE
+            @_setPresence(no)
+          else
             @_setPresence(yes)
           clearTimeout(@_resetPresenceTimeout)
-        @_resetPresenceTimeout = setTimeout(resetPresence, @config.resetTime)
+         if @config.autoReset is true
+              clearTimeout(@_resetContactTimeout)
+              @_resetContactTimeout = setTimeout(( =>
+                @_setContact(!hasContact)
+              ), @config.resetTime)
       )
       super()
 

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -72,8 +72,7 @@ module.exports = {
         description: "This is the child-sensor-id that uniquely identifies one attached sensor"
         type: "number"
       autoReset:
-        description: """Reset the state after resetTime. Usefull for contact sensors, 
-                      that only emit open or close events"""
+        description: "Disable this if your PIR sensors also emit absence."
         type: "boolean"
         default: true
       resetTime:

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -71,6 +71,11 @@ module.exports = {
       sensorid:
         description: "This is the child-sensor-id that uniquely identifies one attached sensor"
         type: "number"
+      autoReset:
+        description: """Reset the state after resetTime. Usefull for contact sensors, 
+                      that only emit open or close events"""
+        type: "boolean"
+        default: true
       resetTime:
         description: "Time after that the PIR presence value is reset to absent"
         type: "number"


### PR DESCRIPTION
Please add this, by default nothing changes for the default PIR and other users.

Unless you add: `autoReset: false` then pimatic won't reset the PIR by itself.
