### PR TITLE
NodeId for new nodes is working now

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Pimatic plugin supporting MySensors as controller. (http://mysensors.org/)
 
 Controllers
 -----------
-  node-id to be fixed in Sensors/Actuator code.
-
   Support for following sensors
   * Temperature and Humidity  ( http://mysensors.org/build/humidity)
   * Temperature and Pressure ( http://mysensors.org/build/pressure)
@@ -43,6 +41,7 @@ You can load the plugin by editing your config.json to include:
       "plugin": "mysensors",
       "driver": "serialport",
       "protocols": "1.4.1",
+      "startingNodeId": 1,
       "driverOptions": {
       "//": "'/dev/ttyUSBx' if using serial Gateway",
       "serialDevice": "/dev/ttyMySensorsGateway", 

--- a/board.coffee
+++ b/board.coffee
@@ -139,7 +139,7 @@ class Board extends events.EventEmitter
             console.log "<- I_VERSION ", payload
           when I_ID_REQUEST
             console.log "<- I_ID_REQUEST ", data
-            @_rfsendNextAvailableSensorId
+            @_rfsendNextAvailableSensorId()
           when I_ID_RESPONSE
             console.log "<- I_ID_RESPONSE ", data
           when I_INCLUSION_MODE


### PR DESCRIPTION
New nodes without nodeId are now getting the next available node id from
the gateway as defined in config.json (startingNodeId)
