### PR TITLE
Better handling of boolean values

### DIFF
--- a/MySensors.coffee
+++ b/MySensors.coffee
@@ -1063,7 +1063,7 @@ module.exports = (env) ->
                   when "round"
                     value = Math.round(parseFloat(result.value))
                   when "boolean"
-                    if result.value is "0"
+                    if parseInt(result.value) is 0
                       value = false
                     else
                       value = true


### PR DESCRIPTION
I experienced a problem while working with boolean values for the multi sensor.
I got boolean values as float (like "0.0") and the plugin could not handle that correctly.
I created a patch which should not interfere with anything and handle this problem.
