### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "MySensors"
   ],
   "dependencies": {
-    "serialport": "~6.2.1"
+    "serialport": "~7.1.5"
   },
   "peerDependencies": {
     "pimatic": ">=0.8.0 <1.0.0"


### PR DESCRIPTION
Serialport does not compile with new installations on buster. With serialport 7.1.5 it does work.